### PR TITLE
[NO-TICKET] remove type declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A TypeScript library that wraps objects in a cache-aware Proxy for faster method calls",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
-  "type": "module",
   "files": [
     "dist/src"
   ],


### PR DESCRIPTION
Declaring the project `type` as `"module"` narrows how other projects can import and use the type files from this library. It's not uncommon to see libraries not declare the type, which should relax the TS compilers strictness with regard to the differences between es modules and commonjs.