### PR TITLE
[NO-TICKET] npm audit fix: Update flatted to 3.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3129,9 +3129,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
Bump flatted from 3.3.3 to 3.4.2 to address CVE-2026-33228 (prototype pollution and unbounded recursion DoS in parse()).