### PR TITLE
[NO-TICKET] Pin npm via Corepack to prevent package-lock churn

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,16 @@ const cachedObj = ff(obj, { cache: customCache });
 - `FASTFORWARD_MODE`: Set the cache mode globally. Valid values: `ON`, `OFF`, `UPDATE_ONLY`, `READ_ONLY`. 
   This provides a default mode when no explicit mode is specified in code. If a mode is explicitly passed to the `fastForward` function, it will override this environment variable.
 
+## Development
+
+This repo pins **npm 11.6.2** via Corepack (specified in the `packageManager` field of `package.json`). When working on this repo, enable Corepack so npm matches the pinned version — this prevents `package-lock.json` churn across the team:
+
+```sh
+corepack enable npm
+npm --version  # Should show 11.6.2
+npm install
+```
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@with-logic/fast-forward",
   "version": "0.1.13",
+  "packageManager": "npm@11.6.2",
   "description": "A TypeScript library that wraps objects in a cache-aware Proxy for faster method calls",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Adds packageManager: npm@11.6.2 and documents `corepack enable npm` in the README. Without a pinned npm version, contributors running different npm versions produce conflicting `peer: true` diffs in package-lock.json. Mirrors the pattern in logic-web.